### PR TITLE
[closes #30] Map Entity 생성날짜 컬럼 추가

### DIFF
--- a/src/main/java/com/muze/domain/map/command/application/dto/ResponseMapDTO.java
+++ b/src/main/java/com/muze/domain/map/command/application/dto/ResponseMapDTO.java
@@ -3,6 +3,8 @@ package com.muze.domain.map.command.application.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Schema(description = "Map 응답 객체")
 public class ResponseMapDTO {
@@ -17,12 +19,14 @@ public class ResponseMapDTO {
 
     private String data;
 
+    private LocalDateTime createdDate;
 
-    public ResponseMapDTO(Long id, Long memberId, String title, String song, String data) {
+    public ResponseMapDTO(Long id, Long memberId, String title, String song, String data, LocalDateTime createdDate) {
         this.id = id;
         this.memberId = memberId;
         this.title = title;
         this.song = song;
         this.data = data;
+        this.createdDate = createdDate;
     }
 }

--- a/src/main/java/com/muze/domain/map/command/application/service/CreateMapService.java
+++ b/src/main/java/com/muze/domain/map/command/application/service/CreateMapService.java
@@ -27,7 +27,8 @@ public class CreateMapService {
                 newMap.getMemberId().getId(),
                 newMap.getTitle(),
                 newMap.getSong(),
-                newMap.getData()
+                newMap.getData(),
+                newMap.getCreatedDate()
         );
 
         return map;

--- a/src/main/java/com/muze/domain/map/command/domain/aggregate/entity/Map.java
+++ b/src/main/java/com/muze/domain/map/command/domain/aggregate/entity/Map.java
@@ -2,8 +2,10 @@ package com.muze.domain.map.command.domain.aggregate.entity;
 import com.muze.domain.map.command.domain.aggregate.vo.MemberVO;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 
 @Getter
@@ -28,11 +30,17 @@ public class Map {
     @Column(columnDefinition = "LONGTEXT")
     private String data;
 
+    @CreatedDate
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
     public Map(MemberVO memberId, String title, String song, String data) {
         this.memberId = memberId;
         this.title = title;
         this.song = song;
         this.data = data;
+        this.createdDate=LocalDateTime.now();
+
     }
 
     public void setData(String data) {

--- a/src/main/java/com/muze/domain/map/query/application/dto/FindMapDTO.java
+++ b/src/main/java/com/muze/domain/map/query/application/dto/FindMapDTO.java
@@ -2,6 +2,8 @@ package com.muze.domain.map.query.application.dto;
 
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class FindMapDTO {
 
@@ -14,6 +16,8 @@ public class FindMapDTO {
     private String song;
 
     private String data;
+
+    private LocalDateTime createdDate;
 
     @Override
     public String toString() {

--- a/src/main/resources/mapper/map/MapMapper.xml
+++ b/src/main/resources/mapper/map/MapMapper.xml
@@ -8,6 +8,7 @@
         <result property="title" column="title"/>
         <result property="song" column="song"/>
         <result property="data" column="data"/>
+        <result property="created_date" column="createDate"/>
     </resultMap>
 
     <select id="findAll" resultMap="FindMap">


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #30 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 생성날짜 컬럼 추가
* Entity에 DB에 저장시 현재 시각을 기준으로 생성되게 설정
---

# 관련 스크린샷

---
<img width="251" alt="image" src="https://github.com/MTVS-Muze/back-end/assets/136034038/e037f2c0-62b4-45a1-8ad1-a19a99ca73de">
---

# 테스트 계획 또는 완료 사항

---
* 통과
