### PR TITLE
[Closes #56]Feat : swagger 정리 및 userprincipal 사용

### DIFF
--- a/src/main/java/com/muze/domain/character/command/application/controller/CharacterController.java
+++ b/src/main/java/com/muze/domain/character/command/application/controller/CharacterController.java
@@ -2,7 +2,14 @@ package com.muze.domain.character.command.application.controller;
 
 import com.muze.domain.character.command.application.dto.CharacterCustomizingDTO;
 import com.muze.domain.character.command.application.service.CharacterCustomizingService;
+import com.muze.global.common.annotation.CurrentMember;
 import com.muze.global.security.principal.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,9 +28,18 @@ public class CharacterController {
         this.characterCustomizingService = characterCustomizingService;
     }
 
+
+    @Operation(summary = "캐릭터 커스터마이징 등록", description = "새로운 커스터마이징을 등록하거나 업데이트함")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "커스터마이징 저장 성공",
+                    content = @Content(
+                            schema = @Schema())),
+    })
     @PostMapping
     public ResponseEntity<?> createOrUpdateCharacter(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Parameter(hidden = true) @CurrentMember UserPrincipal userPrincipal,
             @RequestBody CharacterCustomizingDTO characterCustomizingDTO){
         characterCustomizingDTO.setMemberId(userPrincipal.getId());
         System.out.println("characterCustomizingDTO = " + characterCustomizingDTO);

--- a/src/main/java/com/muze/domain/character/command/application/dto/CharacterCustomizingDTO.java
+++ b/src/main/java/com/muze/domain/character/command/application/dto/CharacterCustomizingDTO.java
@@ -1,5 +1,6 @@
 package com.muze.domain.character.command.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import lombok.ToString;
 @AllArgsConstructor
 @ToString
 public class CharacterCustomizingDTO {
+    @Schema(hidden = true)
     private Long memberId;
     private Integer color;
     private Integer hat;

--- a/src/main/java/com/muze/domain/character/query/application/application/QueryCharacterController.java
+++ b/src/main/java/com/muze/domain/character/query/application/application/QueryCharacterController.java
@@ -3,6 +3,12 @@ package com.muze.domain.character.query.application.application;
 import com.muze.domain.character.query.application.dto.MyCharacterDTO;
 import com.muze.domain.character.query.application.service.FindCharacterService;
 import com.muze.global.security.principal.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,8 +27,17 @@ public class QueryCharacterController {
     }
 
 
+    @Operation(summary = "캐릭터 조회", description = "캐릭터 커스터마이징 조회")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "캐릭터 커스터마이징 조회 성공",
+                    content = @Content(
+                            schema = @Schema())),
+    })
     @GetMapping
-    public ResponseEntity<?> findCharacter(@AuthenticationPrincipal UserPrincipal userPrincipal){
+    public ResponseEntity<?> findCharacter(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal){
         MyCharacterDTO myCharacter= findCharacterService.findCharacter(userPrincipal.getId());
         return ResponseEntity.ok(myCharacter);
     }

--- a/src/main/java/com/muze/domain/friend/command/application/controller/FriendController.java
+++ b/src/main/java/com/muze/domain/friend/command/application/controller/FriendController.java
@@ -3,6 +3,15 @@ package com.muze.domain.friend.command.application.controller;
 import com.muze.domain.friend.command.application.dto.FriendDTO;
 import com.muze.domain.friend.command.application.service.AddFriendService;
 import com.muze.domain.friend.command.application.service.DeleteFriendService;
+import com.muze.domain.map.command.application.dto.ResponseMapDTO;
+import com.muze.global.common.annotation.CurrentMember;
+import com.muze.global.security.principal.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,16 +35,33 @@ public class FriendController {
         this.deleteFriendService = deleteFriendService;
     }
 
+    @Operation(summary = "친구 등록", description = "다른 사용자를 친구로 등록")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "친구 저장 성공",
+                    content = @Content(
+                            schema = @Schema())),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "필요한 값을 보내주지 않음",
+                    content = @Content(
+                            schema = @Schema())),
+    })
+
     @PostMapping
     public ResponseEntity<?> addFriend(
-            @RequestBody @Valid FriendDTO friendDTO, BindingResult bindingResult
-    ) {
+            @RequestBody @Valid FriendDTO friendDTO, BindingResult bindingResult,
+            @Parameter(hidden = true) @CurrentMember UserPrincipal userPrincipal
+            ) {
         if (bindingResult.hasErrors()) {
             List<FieldError> list = bindingResult.getFieldErrors();
             for (FieldError error : list) {
                 return new ResponseEntity<>(error.getDefaultMessage(), HttpStatus.BAD_REQUEST);
             }
         }
+
+        friendDTO.setMemberId(userPrincipal.getId());
         if (addFriendService.checkFriend(friendDTO)) {
             return ResponseEntity.ok("이미 친구로 등록된 유저입니다.");
 
@@ -46,10 +72,19 @@ public class FriendController {
 
     }
 
+
+    @Operation(summary = "친구 삭제", description = "등록된 친구를 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "친구 삭제 성공",
+                    content = @Content(
+                            schema = @Schema()))
+    })
     @DeleteMapping
     public ResponseEntity<?> deleteFriend(
-            @RequestBody @Valid FriendDTO friendDTO, BindingResult bindingResult
-
+            @RequestBody @Valid FriendDTO friendDTO, BindingResult bindingResult,
+            @Parameter(hidden = true) @CurrentMember UserPrincipal userPrincipal
     ) {
         if (bindingResult.hasErrors()) {
             List<FieldError> list = bindingResult.getFieldErrors();
@@ -57,6 +92,7 @@ public class FriendController {
                 return new ResponseEntity<>(error.getDefaultMessage(), HttpStatus.BAD_REQUEST);
             }
         }
+        friendDTO.setMemberId(friendDTO.getMemberId());
         deleteFriendService.deleteFriend(friendDTO);
         return ResponseEntity.ok("정상적으로 삭제되었습니다.");
     }

--- a/src/main/java/com/muze/domain/friend/command/application/dto/FriendDTO.java
+++ b/src/main/java/com/muze/domain/friend/command/application/dto/FriendDTO.java
@@ -1,6 +1,7 @@
 package com.muze.domain.friend.command.application.dto;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -11,14 +12,24 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 @ToString
 public class FriendDTO {
-    @NotNull(message = "memberId는 Null일 수 없습니다.")
+    @Schema(hidden = true)
     private Long memberId;
     @NotNull(message = "friendId는 Null일 수 없습니다.")
+    @Schema(description = "친구의 memberId", defaultValue = "1")
     private Long friendId;
 
 
     public FriendDTO(Long memberId, Long friendId) {
         this.memberId = memberId;
+        this.friendId = friendId;
+    }
+
+    public void setMemberId(Long memberId) {
+        this.memberId = memberId;
+    }
+
+    public FriendDTO(Long friendId) {
+
         this.friendId = friendId;
     }
 }

--- a/src/main/java/com/muze/domain/friend/query/application/controller/FriendQueryController.java
+++ b/src/main/java/com/muze/domain/friend/query/application/controller/FriendQueryController.java
@@ -3,6 +3,8 @@ package com.muze.domain.friend.query.application.controller;
 import com.muze.domain.friend.query.application.dto.FriendListsDTO;
 import com.muze.domain.friend.query.application.service.FindFriendsService;
 import com.muze.domain.member.query.application.dto.FindMemberDTO;
+import com.muze.global.common.annotation.CurrentMember;
+import com.muze.global.security.principal.UserPrincipal;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -22,10 +24,10 @@ public class FriendQueryController {
     }
 
     @GetMapping
-    public ResponseEntity<?> findFriend(@RequestParam Long memberId){
+    public ResponseEntity<?> findFriend(@CurrentMember UserPrincipal userPrincipal){
 
         FriendListsDTO friendListsDTO = new FriendListsDTO(findFriendsService.findFriendsInfo(
-                findFriendsService.findFriends(memberId)));
+                findFriendsService.findFriends(userPrincipal.getId())));
 
         return ResponseEntity.ok(friendListsDTO);
     }

--- a/src/main/java/com/muze/domain/like/command/application/controller/LikeController.java
+++ b/src/main/java/com/muze/domain/like/command/application/controller/LikeController.java
@@ -6,6 +6,14 @@ import com.muze.domain.like.command.application.service.EnrollLikeService;
 import com.muze.domain.like.command.domain.repository.LikeRepository;
 import com.muze.domain.like.query.application.dto.LikeInfoDTO;
 import com.muze.domain.like.query.application.service.LikeInfoService;
+import com.muze.global.common.annotation.CurrentMember;
+import com.muze.global.security.principal.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,9 +41,22 @@ public class LikeController {
         this.likeRepository = likeRepository;
     }
 
+    @Operation(summary = "좋아요 등록", description = "좋아요를 등록하거나 취소함")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "친구 저장 성공",
+                    content = @Content(
+                            schema = @Schema())),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "필요한 값을 보내주지 않음",
+                    content = @Content(
+                            schema = @Schema())),
+    })
     @PostMapping
     public ResponseEntity<?> enrollOrDeleteLike(@Valid LikeDTO likeDTO, BindingResult bindingResult
-//                                             ,@AuthenticationPrincipal UserPrincipal userPrincipal
+                                             ,@Parameter(hidden = true) @CurrentMember UserPrincipal userPrincipal
     ){
         if(bindingResult.hasErrors()){
             List<FieldError> list = bindingResult.getFieldErrors();
@@ -43,6 +64,8 @@ public class LikeController {
                 return new ResponseEntity<>(error.getDefaultMessage() , HttpStatus.BAD_REQUEST);
             }
         }
+
+        likeDTO.setMemberId(userPrincipal.getId());
 
         if(likeInfoService.isLiked(likeDTO)){
             cancelLikeService.CancelLike(likeDTO);

--- a/src/main/java/com/muze/domain/like/command/application/dto/LikeDTO.java
+++ b/src/main/java/com/muze/domain/like/command/application/dto/LikeDTO.java
@@ -1,6 +1,7 @@
 package com.muze.domain.like.command.application.dto;
 
 import com.muze.domain.like.command.domain.aggregate.originenum.Origin;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -14,17 +15,26 @@ import javax.validation.constraints.Positive;
 @NoArgsConstructor
 @ToString
 public class LikeDTO {
-    @NotNull(message = "memberId는 Null일 수 없습니다.")
-    @Positive(message = "memberId는 음수일 수 없습니다.")
+    @Schema(hidden = true)
     private Long memberId;
     private Origin origin;
     @NotNull(message = "originId는 Null일 수 없습니다.")
-    @Positive(message = "originId는 음수일 수 없습ㄴ디ㅏ.")
+    @Positive(message = "originId는 음수일 수 없습니다.")
+    @Schema(description = "MAP의 id", defaultValue = "1")
     private Long originId;
     public LikeDTO(Long memberId, Origin origin, Long originId) {
         this.memberId = memberId;
         this.origin = origin;
         this.originId = originId;
+    }
+
+    public LikeDTO(Origin origin, Long originId) {
+        this.origin = origin;
+        this.originId = originId;
+    }
+
+    public void setMemberId(Long memberId) {
+        this.memberId = memberId;
     }
 }
 

--- a/src/main/java/com/muze/global/configration/SwaggerConfiguration.java
+++ b/src/main/java/com/muze/global/configration/SwaggerConfiguration.java
@@ -56,4 +56,15 @@ public class SwaggerConfiguration {
                 .pathsToMatch(paths)
                 .build();
     }
+
+    @Bean
+    public GroupedOpenApi character(){
+        String[] paths ={"/character/**"};
+
+        return GroupedOpenApi
+                .builder()
+                .group("Muze Sawgger v1-character")
+                .pathsToMatch(paths)
+                .build();
+    }
 }


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #56 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
*  swagger 정리
* controller에서 userprincipal을 사용하도록 수정하였습니다.
---

# 관련 스크린샷

---
* 
<img width="1062" alt="image" src="https://github.com/MTVS-Muze/back-end/assets/74136791/64c41972-cc1c-4f85-88ec-b697f2e05893">

---

# 테스트 계획 또는 완료 사항

---
* 없음
